### PR TITLE
Serve definitions from ttl file with any rdflib serialization type

### DIFF
--- a/dwinston/README.md
+++ b/dwinston/README.md
@@ -1,0 +1,31 @@
+# Instructions
+
+To run the server locally, (optionally) create a new Python virtualenv of your preferred flavor and install the dependencies.
+
+```shell
+pip install -r requirements
+```
+
+You can then run the server with:
+
+```shell
+uvicorn --reload --port=8000 main:app
+```
+
+## Example queries:
+
+-   To get an HTML response:
+
+    ```shell
+    curl http://localhost:8000/2021/04/marda-dd/test\#helloWorld
+    ```
+
+    or alternatively just visit http://localhost:8000/2021/04/marda-dd/test\#helloWorld in your browser with the server running.
+
+-   To get responses in an RDF format:
+
+    ```shell
+    curl -H "Accept: text/turtle" http://localhost:8000/2021/04/marda-dd/test\#helloWorld
+    ```
+
+    where `text/turtle` can be replaced with any [rdflib-compatible format or mime-type](https://rdflib.readthedocs.io/en/stable/plugin_serializers.html), e.g., `application/rdf+xml`, `nquads`.

--- a/dwinston/hello_world.ttl
+++ b/dwinston/hello_world.ttl
@@ -1,0 +1,6 @@
+@base <http://ns.polyneme.xyz/2021/04/marda-dd/test> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<#helloWorld>
+  rdfs:label "hello world" ;
+  rdfs:comment "This is a beautiful term." .

--- a/dwinston/hello_world.ttl
+++ b/dwinston/hello_world.ttl
@@ -4,3 +4,7 @@
 <#helloWorld>
   rdfs:label "hello world" ;
   rdfs:comment "This is a beautiful term." .
+
+<#howdyWorld>
+  rdfs:label "howdy world" ;
+  rdfs:comment "This is a vulgar term." .

--- a/dwinston/requirements.txt
+++ b/dwinston/requirements.txt
@@ -1,1 +1,2 @@
 fastapi[all]
+rdflib~=5.0


### PR DESCRIPTION
Hi @dwinston, not sure if you are expecting PRs at this stage, but I've just had a lunchtime play-around to familiarise myself with [rdflib](https://rdflib.readthedocs.io/) so I thought I would get the ball rolling.

This PR does the following:

- moves "hello world" def to a ttl file and adds a second dummy definition
- added method for rendering rdflib graph as html based on existing format that can handle multiple terms
- accept and emit any rdflib mime-type/format based on `Accept` parameter, e.g. `Accept: application/rdf+xml` or `Accept: nquads`.
- adds a short README describing how to install the server and perform some example queries